### PR TITLE
feat/DJ: PIZ7 Add Failure Alert when order is not created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ migrations/
 pizza.sqlite
 .vscode/launch.json
 .vscode/tasks.json
+.vscode/*.json

--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -19,13 +19,13 @@ class OrderController(BaseController):
     def create(cls, order: dict):
         current_order = order.copy()
         if not check_required_keys(cls.__required_info, current_order):
-            return 'Invalid order payload', None
+            return None, 'Invalid order payload'
 
         size_id = current_order.get('size_id')
         size = SizeManager.get_by_id(size_id)
 
         if not size:
-            return 'Invalid size for Order', None
+            return None, 'Invalid size for Order'
 
         ingredient_ids = current_order.pop('ingredients', [])
         try:


### PR DESCRIPTION
Description:
Fix the endpoint to returns an error when the order is not created because of missing required fields.

Ticket Link:
[PIZ7](https://trello.com/c/HIjU9fd3/1-piz7-add-failure-alert-when-order-is-not-created-%F0%9F%9A%A8)

Test:
![Screen Shot 2024-04-08 at 14 59 08](https://github.com/domenica-jimenez/python-pizza-planet/assets/59580211/021f455f-6681-4548-a89a-f38b39096a38)
